### PR TITLE
Attach Barrett transform to BigInteger for use in dependant modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 (function(){
-    
+
     // Copyright (c) 2005  Tom Wu
     // All Rights Reserved.
     // See "LICENSE" for details.
@@ -1209,6 +1209,9 @@
     // JSBN-specific extension
     BigInteger.prototype.square = bnSquare;
 
+    // Expose the Barrett function
+    BigInteger.prototype.Barrett = Barrett
+
     // BigInteger interfaces not implemented in jsbn:
 
     // BigInteger(int signum, byte[] magnitude)
@@ -1222,5 +1225,5 @@
     } else {
         this.BigInteger = BigInteger;
     }
-    
+
 }).call(this);


### PR DESCRIPTION
Howdy,

Thanks for publishing this as an npm module.

The change here simply attaches the Barrett transform to the exported BigInteger object so that it can be used with Tom Wu's elliptic curve algorithms.
