### PR TITLE
Fix undefined DV

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@
       this.t = 1;
       this.s = (x<0)?-1:0;
       if(x > 0) this[0] = x;
-      else if(x < -1) this[0] = x+DV;
+      else if(x < -1) this[0] = x+this.DV;
       else this.t = 0;
     }
 


### PR DESCRIPTION
This is the bugfix from version 1.4 of _jsbn.js_ (see [History](http://www-cs-students.stanford.edu/~tjw/jsbn/)) which fixes an undefined variable in the _bnpFromInt_ function.

Without this fix, the following will throw _ReferenceError: DV is not defined_:

```
var x = new BigInteger('3');
x.fromInt(-2);
```
