### PR TITLE
do not use fallback if random values already generated

### DIFF
--- a/index.js
+++ b/index.js
@@ -1258,7 +1258,7 @@
 		  for(t = 0; t < 32; ++t)
 			rng_pool[rng_pptr++] = ua[t];
 		}
-		if(navigator.appName == "Netscape" && navigator.appVersion < "5") {
+		else if(navigator.appName == "Netscape" && navigator.appVersion < "5") {
 		  // Extract entropy (256 bits) from NS4 RNG if available
 		  var z = window.crypto.random(32);
 		  for(t = 0; t < z.length; ++t)


### PR DESCRIPTION
Some user-agents pass the check on line 1261 even if `window.crypto.getRandomValues` has been invoked.