### PR TITLE
Added support for ES6 default imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1347,6 +1347,7 @@
 
     if (typeof exports !== 'undefined') {
         exports = module.exports = {
+            default: BigInteger,
             BigInteger: BigInteger,
             SecureRandom: SecureRandom,
         };


### PR DESCRIPTION
`import BigInteger from 'jsbn'` instead of `import { BigInteger } from 'jsbn'`
