### PR TITLE
Do not package examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "type": "git",
     "url": "https://github.com/andyperlitch/jsbn.git"
   },
+  "files": [],
   "keywords": [
     "biginteger",
     "bignumber",


### PR DESCRIPTION
Examples are not used at runtime so there is no need to package them.

All the other files will be included by default, see https://docs.npmjs.com/files/package.json#files
