### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@
 
       // Remove the notation string if any has been detected
       if (isDetected) {
-        s = s.substr(2);
+        s = s.slice(2);
       }
     }
 
@@ -748,7 +748,7 @@
       r = '';
     this.divRemTo(d, y, z);
     while (y.signum() > 0) {
-      r = (a + z.intValue()).toString(b).substr(1) + r;
+      r = (a + z.intValue()).toString(b).slice(1) + r;
       y.divRemTo(d, y, z);
     }
     return z.intValue().toString(b) + r;


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.